### PR TITLE
Improvements for iframed demo

### DIFF
--- a/example.css
+++ b/example.css
@@ -14,3 +14,16 @@ html, body {
   /* This prevents reference labels from being drawn twice at the same time, which is bad */
   display: none;
 }
+
+/* Hide zoom control on touch devices, which interferes with project page navigation overlay */
+.leaflet-touch .leaflet-control-zoom {
+    display: none;
+}
+
+/* For non touch devices, move control out of the way at small window widths */
+@media (max-width: 752px) {
+    /* 767px - 15px for scrollbar */
+    .mapzen-demo-iframed .leaflet-top {
+      top: 50px;
+    }
+}

--- a/example.js
+++ b/example.js
@@ -9,7 +9,7 @@ if (window.self !== window.top) {
 }
 
 if (map.attributionControl) {
-  map.attributionControl.addAttribution('<a href="https://libraries.io/bower/hoverboard/v1.0.1">Hoverboard</a> | © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a> | <a href="https://mapzen.com/projects/vector-tiles" title="Tiles courtesy of Mapzen" target="_blank">Mapzen</a>');
+  map.attributionControl.addAttribution('<a href="https://libraries.io/bower/hoverboard/v1.0.1" target="_top">Hoverboard</a> | © <a href="https://www.openstreetmap.org/copyright" target="_top">OpenStreetMap contributors</a> | <a href="https://mapzen.com/projects/vector-tiles" title="Tiles courtesy of Mapzen" target="_top">Mapzen</a>');
 }
 
 var url  = window.xyz_tile_source_url;

--- a/example.js
+++ b/example.js
@@ -6,6 +6,7 @@ var map = L.map('map', {
 
 if (window.self !== window.top) {
   map.scrollWheelZoom.disable();
+  document.documentElement.className += ' mapzen-demo-iframed';
 }
 
 if (map.attributionControl) {

--- a/topojson.html
+++ b/topojson.html
@@ -30,8 +30,6 @@
     });
   </script>
 
-  <script src='//s3.amazonaws.com/assets-staging.mapzen.com/ui/components/bug/bug.min.js'></script>
-  
   <script src="example.js"></script>
 
 </body>


### PR DESCRIPTION
- Hide zoom control on touch devices
- For non touch devices, move control out of the way at small window widths
- Remove duplicate bug.js
- Open attribution links on top of window
